### PR TITLE
Make PriceComp fields public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,9 @@ pub struct PriceInfo
 #[repr(C)]
 pub struct PriceComp
 {
-  publisher  : AccKey,         // key of contributing quoter
-  agg        : PriceInfo,      // contributing price to last aggregate
-  latest     : PriceInfo       // latest contributing price (not in agg.)
+  pub publisher  : AccKey,         // key of contributing quoter
+  pub agg        : PriceInfo,      // contributing price to last aggregate
+  pub latest     : PriceInfo       // latest contributing price (not in agg.)
 }
 
 // Price account structure


### PR DESCRIPTION
While writing some unit tests for deserializing the Pyth data types, I couldn't create a PriceComp of my own. I believe the pubs may have been desired there anyway (it's the only struct without them).