### PR TITLE
lib.rs: make Ema fields public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ pub struct PriceComp
 pub struct Ema
 {
   pub val        : i64,        // current value of ema
-  numer          : i64,        // numerator state for next update
-  denom          : i64         // denominator state for next update
+  pub numer      : i64,        // numerator state for next update
+  pub denom      : i64         // denominator state for next update
 }
 
 // Price account structure


### PR DESCRIPTION
Just a two-liner, similar to the `PriceComp` one. I need this to use the Ema data without casting to a yet another local structure, which I am doing now.